### PR TITLE
Remove CanDeserialize, catch InvalidProtocolBufferException and rethrow within a PersistenceException

### DIFF
--- a/src/HEAL.Attic.Tests/ExceptionTests.cs
+++ b/src/HEAL.Attic.Tests/ExceptionTests.cs
@@ -1,0 +1,55 @@
+﻿#region License Information
+/*
+ * This file is part of HEAL.Attic which is licensed under the MIT license.
+ * See the LICENSE file in the project root for more information.
+ */
+#endregion
+
+using System.IO;
+using System.Text;
+using Google.Protobuf;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HEAL.Attic.Tests {
+
+  [TestClass]
+  public class ExceptionTests {
+    [TestMethod]
+    public void TestMissingDeflateStreamException() {
+      var tmpFile = Path.GetTempFileName();
+      using (var outStream = File.OpenWrite(tmpFile)) {
+        new ProtoBufSerializer().Serialize(new TestStorable(), outStream);
+      }
+      // This must fail, because Serialize did not use a DeflateStream
+      // However, Deserialize(string path) uses a DeflateStream
+      try {
+        var instance = (TestStorable)new ProtoBufSerializer().Deserialize(tmpFile);
+        Assert.Fail("This method should not succeed.");
+      } catch (PersistenceException e) {
+        Assert.AreEqual("Invalid data in stream. Maybe the data was serialized with or without using a DeflateStream.", e.Message);
+        Assert.IsInstanceOfType(e.InnerException, typeof(InvalidDataException));
+      }
+      File.Delete(tmpFile);
+    }
+
+    [TestMethod]
+    public void TestInvalidFormatException() {
+      var tmpFile = Path.GetTempFileName();
+      File.WriteAllBytes(tmpFile, Encoding.UTF8.GetBytes("Hello Attic"));
+      // This must fail, because this file is not a valid format of Attic
+      using (var stream = File.OpenRead(tmpFile)) {
+        try {
+          var instance = (TestStorable)new ProtoBufSerializer().Deserialize(stream, disposeStream: false);
+          Assert.Fail("This method should not succeed.");
+        } catch (PersistenceException e) {
+          Assert.AreEqual("Invalid format.", e.Message);
+          Assert.IsInstanceOfType(e.InnerException, typeof(InvalidProtocolBufferException));
+        }
+      }
+      File.Delete(tmpFile);
+    }
+
+    [StorableType("5d89096d-24f1-4e9b-8bb1-b65ebd771d71")]
+    private class TestStorable { }
+  }
+}

--- a/src/HEAL.Attic/Core/Serializer.cs
+++ b/src/HEAL.Attic/Core/Serializer.cs
@@ -95,22 +95,5 @@ namespace HEAL.Attic {
       }
     }
     protected abstract Bundle DeserializeBundle(Stream stream, bool disposeStream = true);
-
-    public virtual bool CanDeserialize(string path) {
-      using (var fileStream = new FileStream(path, FileMode.Open)) {
-        using (var zipStream = new DeflateStream(fileStream, CompressionMode.Decompress)) {
-          return CanDeserialize(zipStream);
-        }
-      }
-    }
-    public virtual bool CanDeserialize(byte[] data) {
-      using (var memoryStream = new MemoryStream(data)) {
-        using (var zipStream = new DeflateStream(memoryStream, CompressionMode.Decompress)) {
-          return CanDeserialize(zipStream);
-        }
-      }
-    }
-
-    public abstract bool CanDeserialize(Stream stream);
   }
 }

--- a/src/HEAL.Attic/Core/Serializer.cs
+++ b/src/HEAL.Attic/Core/Serializer.cs
@@ -66,7 +66,11 @@ namespace HEAL.Attic {
                                       out SerializationInfo info,
                                       bool disposeStream = true,
                                       CancellationToken cancellationToken = default(CancellationToken)) {
-      return Mapper.ToObject(DeserializeBundle(stream, disposeStream), out info, cancellationToken);
+      try {
+        return Mapper.ToObject(DeserializeBundle(stream, disposeStream), out info, cancellationToken);
+      } catch (InvalidDataException ide) {
+        throw new PersistenceException("Invalid data in stream. Maybe the data was serialized with or without using a DeflateStream.", ide);
+      }
     }
     public virtual object Deserialize(string path,
                                       CancellationToken cancellationToken = default(CancellationToken)) {

--- a/src/HEAL.Attic/ISerializer.cs
+++ b/src/HEAL.Attic/ISerializer.cs
@@ -45,8 +45,5 @@ namespace HEAL.Attic {
     object Deserialize(byte[] data,
                        out SerializationInfo info,
                        CancellationToken cancellationToken = default(CancellationToken));
-    bool CanDeserialize(Stream stream);
-    bool CanDeserialize(string path);
-    bool CanDeserialize(byte[] data);
   }
 }


### PR DESCRIPTION
This should provide an alternative to catch invalid format exceptions (fixes #14)