### PR TITLE
Improve exception messages

### DIFF
--- a/src/HEAL.Attic.Tests/ExceptionTests.cs
+++ b/src/HEAL.Attic.Tests/ExceptionTests.cs
@@ -63,5 +63,170 @@ namespace HEAL.Attic.Tests {
 
     [StorableType("5d89096d-24f1-4e9b-8bb1-b65ebd771d71")]
     private class TestStorable { }
+
+
+    [StorableType("2F344E0B-29CB-4910-8CC1-6ADE2A1F0DB8")]
+    private class Type_2F344E0B { }
+
+    // registration of this type with guid of type Type_2F344E0B should fail
+    private class TypeWithDuplicateGuid { }
+
+    [TestMethod]
+    public void DuplicateGuidTest() {
+      var guid = StorableTypeAttribute.GetStorableTypeAttribute(typeof(Type_2F344E0B)).Guid;
+
+      try {
+        TypeManipulation.RegisterType(guid, typeof(TypeWithDuplicateGuid));
+        Assert.Fail("This method should not succeed.");
+      } catch (PersistenceException e) {
+        Assert.AreEqual($"PersistenceException in type HEAL.Attic.Tests.ExceptionTests+{nameof(TypeWithDuplicateGuid)}:" +
+          $" The GUID {guid} is already used by type HEAL.Attic.Tests.ExceptionTests+{nameof(Type_2F344E0B)}.", e.Message);
+        Assert.AreEqual(TypeManipulation.GetType(guid), typeof(Type_2F344E0B));
+      }
+    }
+
+    [StorableType("CDAE4A2A-1A7D-44A6-A401-D74120949EE8")]
+    private class TypeWithoutValidCtor {
+      // no default ctor
+      // no storable ctor
+      public TypeWithoutValidCtor(object o) { }
+    }
+
+    [TestMethod]
+    public void MissingConstructorTest() {
+      var x = new TypeWithoutValidCtor(null);
+      var ser = new ProtoBufSerializer();
+      try {
+        ser.Serialize(x);
+        Assert.Fail("This method should not succeed.");
+      } catch (PersistenceException e) {
+        Assert.AreEqual($"PersistenceException in type HEAL.Attic.Tests.ExceptionTests+{nameof(TypeWithoutValidCtor)}:" +
+          " No storable constructor or parameterless constructor found.", e.Message);
+      }
+    }
+
+    [StorableType("DF90167A-2616-412C-97DA-8CBAAEFA9EC2")]
+    private class TypeWithInvalidStorableField {
+      // cannot use OldName and Name at the same time
+      [Storable(OldName = "a", Name = "b")]
+      public object o;
+    }
+
+    [TestMethod]
+    public void UseOfNameAndOldNameFieldTest() {
+      var x = new TypeWithInvalidStorableField();
+      var ser = new ProtoBufSerializer();
+      try {
+        ser.Serialize(x);
+        Assert.Fail("This method should not succeed.");
+      } catch (PersistenceException e) {
+        Assert.AreEqual($"PersistenceException in type HEAL.Attic.Tests.ExceptionTests+{nameof(TypeWithInvalidStorableField)}:" +
+          $" Field {nameof(x.o)} cannot use Name and OldName at the same time.", e.Message);
+      }
+    }
+
+    [StorableType("826ED91B-636C-40AE-8B4E-EA04C3BC57CB")]
+    private class TypeWithInvalidStorableFieldPath {
+      // path is invalid
+      [Storable(Name = "826ED91B-636C-40AE-8B4E-EA04C3BC57CB..o")]
+      public object o;
+    }
+
+    [TestMethod]
+    public void InvalidFieldPathTest() {
+      var x = new TypeWithInvalidStorableFieldPath();
+      var ser = new ProtoBufSerializer();
+      try {
+        ser.Serialize(x);
+        Assert.Fail("This method should not succeed.");
+      } catch (PersistenceException e) {
+        Assert.AreEqual($"PersistenceException in type HEAL.Attic.Tests.ExceptionTests+{nameof(TypeWithInvalidStorableFieldPath)}:" +
+          $" Field {nameof(x.o)} has an invalid path.", e.Message);
+      }
+    }
+
+    [StorableType("949392EA-6D80-42EB-94F2-89488F0ED6B0")]
+    private class TypeWithPropertyUsingOldNameAndName {
+      // cannot use OldName and Name at the same time
+      [Storable(OldName = "a", Name = "b")]
+      public object O { get; set; }
+    }
+
+    [TestMethod]
+    public void UseOfNameAndOldNamePropertyTest() {
+      var x = new TypeWithPropertyUsingOldNameAndName();
+      var ser = new ProtoBufSerializer();
+      try {
+        ser.Serialize(x);
+        Assert.Fail("This method should not succeed.");
+      } catch (PersistenceException e) {
+        Assert.AreEqual($"PersistenceException in type HEAL.Attic.Tests.ExceptionTests+{nameof(TypeWithPropertyUsingOldNameAndName)}:" +
+          $" Property {nameof(x.O)} cannot use Name and OldName at the same time.", e.Message);
+      }
+    }
+
+    [StorableType("1A146AE3-6D6F-4E5E-A79A-80AC22C8A75F")]
+    private class TypeWithPropertyUsingAllowOneWayAndName {
+      // cannot use OldName and AllowOneWay at the same time
+#pragma warning disable CS0618 // Type or member is obsolete
+      [Storable(OldName = "a", AllowOneWay = true)]
+#pragma warning restore CS0618 // Type or member is obsolete
+      public object O { get; set; }
+    }
+
+    [TestMethod]
+    public void UseOfAllowOneWayAndOldNamePropertyTest() {
+      var x = new TypeWithPropertyUsingAllowOneWayAndName();
+      var ser = new ProtoBufSerializer();
+      try {
+        ser.Serialize(x);
+        Assert.Fail("This method should not succeed.");
+      } catch (PersistenceException e) {
+        Assert.AreEqual($"PersistenceException in type HEAL.Attic.Tests.ExceptionTests+{nameof(TypeWithPropertyUsingAllowOneWayAndName)}:" +
+          $" Property {nameof(x.O)} cannot use AllowOneWay and OldName at the same time.", e.Message);
+      }
+    }
+
+    [StorableType("F1FB543A-EC1C-411E-AB5E-532C39E9985C")]
+    private class ReadableOnlyType {
+      // no setter
+      // no AllowOneWay
+      // no OldName
+      [Storable]
+      public object O { get; }
+    }
+
+    [TestMethod]
+    public void OmittingAllowOneWayOrOldNameTest() {
+      var x = new ReadableOnlyType();
+      var ser = new ProtoBufSerializer();
+      try {
+        ser.Serialize(x);
+        Assert.Fail("This method should not succeed.");
+      } catch (PersistenceException e) {
+        Assert.AreEqual($"PersistenceException in type HEAL.Attic.Tests.ExceptionTests+{nameof(ReadableOnlyType)}:" +
+          $" Property {nameof(x.O)} must be readable and writable or have one way serialization explicitly enabled or use OldName.", e.Message);
+      }
+    }
+
+    [StorableType("36920F6B-1212-408F-8CF9-0C7231546CE2")]
+    private class TypeWithInvalidStorablePropertyPath {
+      // path is invalid
+      [Storable(Name = "36920F6B-1212-408F-8CF9-0C7231546CE2..o")]
+      public object O { get; set; }
+    }
+
+    [TestMethod]
+    public void InvalidPropertyPathTest() {
+      var x = new TypeWithInvalidStorablePropertyPath();
+      var ser = new ProtoBufSerializer();
+      try {
+        ser.Serialize(x);
+        Assert.Fail("This method should not succeed.");
+      } catch (PersistenceException e) {
+        Assert.AreEqual($"PersistenceException in type HEAL.Attic.Tests.ExceptionTests+{nameof(TypeWithInvalidStorablePropertyPath)}:" +
+          $" Property {nameof(x.O)} has an invalid path.", e.Message);
+      }
+    }
   }
 }

--- a/src/HEAL.Attic.Tests/TypeManipulation.cs
+++ b/src/HEAL.Attic.Tests/TypeManipulation.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace HEAL.Attic.Tests {
+  public static class TypeManipulation {
+    // the following are necessary to test backwards compatibility test cases
+    private static Dictionary<Guid, Type> guid2Type;
+    private static Dictionary<Type, Guid> type2Guid;
+    private static Dictionary<Type, TypeInfo> typeInfos;
+    private static PropertyInfo guidPropertyInfo = typeof(StorableTypeAttribute).GetProperty("Guid");
+
+    static TypeManipulation() {
+      var guid2TypeFieldInfo = typeof(StaticCache).GetField("guid2Type", BindingFlags.NonPublic | BindingFlags.Instance);
+      var type2GuidFieldInfo = typeof(StaticCache).GetField("type2Guid", BindingFlags.NonPublic | BindingFlags.Instance);
+      var typeInfosFieldInfo = typeof(StaticCache).GetField("typeInfos", BindingFlags.NonPublic | BindingFlags.Instance);
+
+      guid2Type = (Dictionary<Guid, Type>)guid2TypeFieldInfo.GetValue(Mapper.StaticCache);
+      type2Guid = (Dictionary<Type, Guid>)type2GuidFieldInfo.GetValue(Mapper.StaticCache);
+      typeInfos = (Dictionary<Type, TypeInfo>)typeInfosFieldInfo.GetValue(Mapper.StaticCache);
+    }
+
+    public static void RegisterType(Guid guid, Type type) {
+      Mapper.StaticCache.RegisterType(guid, type);
+    }
+
+    public static void DeregisterType(Guid guid) {
+      if (!guid2Type.ContainsKey(guid)) return;
+      type2Guid.Remove(guid2Type[guid]);
+      guid2Type.Remove(guid);
+    }
+
+    public static Type GetType(Guid guid) {
+      return guid2Type[guid];
+    }
+
+    public static TypeInfo GetTypeInfo(Type type) {
+      return Mapper.StaticCache.GetTypeInfo(type);
+    }
+
+    public static void ReplaceTypeImplementation(Type old, Guid oldGuid, Type @new) {
+      DeregisterType(oldGuid);
+      DeregisterType(StorableTypeAttribute.GetStorableTypeAttribute(@new).Guid);
+
+      RegisterType(oldGuid, @new);
+      SetTypeGuid(@new, oldGuid);
+      typeInfos.Remove(old);
+    }
+
+    public static void SetTypeGuid(Type type, Guid guid) {
+      var typeInfo = GetTypeInfo(type);
+      guidPropertyInfo.SetValue(typeInfo.StorableTypeAttribute, guid);
+      var reflectMethod = typeInfo.GetType().GetMethod("Reflect", BindingFlags.NonPublic | BindingFlags.Instance);
+      reflectMethod.Invoke(typeInfo, new object[0]);
+    }
+  }
+}

--- a/src/HEAL.Attic/Core/PersistenceException.cs
+++ b/src/HEAL.Attic/Core/PersistenceException.cs
@@ -51,6 +51,8 @@ namespace HEAL.Attic {
       }
     }
 
+    public PersistenceException(string message, Type type) : this($"{nameof(PersistenceException)} in type {type.FullName}: {message}") { }
+
     protected PersistenceException(System.Runtime.Serialization.SerializationInfo info, StreamingContext context) : base(info, context) { }
 
     /// <summary>

--- a/src/HEAL.Attic/Core/StaticCache.cs
+++ b/src/HEAL.Attic/Core/StaticCache.cs
@@ -150,6 +150,7 @@ namespace HEAL.Attic {
           if (StorableTypeAttribute.IsStorableType(t)) {
             type2Guid.Add(t, StorableTypeAttribute.GetStorableTypeAttribute(t).Guid);
             foreach (var guid in StorableTypeAttribute.GetStorableTypeAttribute(t).Guids) {
+              if (guid2Type.ContainsKey(guid)) throw new PersistenceException($"The GUID {guid} is already used by type {guid2Type[guid]}.", t);
               guid2Type.Add(guid, t);
             }
           } else if (typeof(IStorableTypeMap).IsAssignableFrom(t) && !t.IsInterface && !t.IsAbstract) {
@@ -177,6 +178,7 @@ namespace HEAL.Attic {
       if (type == null) throw new ArgumentNullException(nameof(type));
       lock (locker) {
         foreach (var guid in guids) {
+          if (guid2Type.ContainsKey(guid)) throw new PersistenceException($"The GUID {guid} is already used by type {guid2Type[guid]}.", type);
           guid2Type.Add(guid, type);
         }
         type2Guid.Add(type, guids[0]);


### PR DESCRIPTION
Improves the exception message of PersistenceExceptions thrown during TypeInfo creation by adding information about the relevant type and property or field. Furthermore, updates exceptions thrown because of duplicate GUIDs to include information on which type was already registered with the respective GUID.

Closes #26.