### PR TITLE
Add null check to DictionaryTransformer

### DIFF
--- a/src/HEAL.Attic/Transformers/DictionaryTransformer.cs
+++ b/src/HEAL.Attic/Transformers/DictionaryTransformer.cs
@@ -66,7 +66,7 @@ namespace HEAL.Attic {
         if (mapper.CancellationToken.IsCancellationRequested) return;
         var key = mapper.GetObject(keys[i]);
         var value = mapper.GetObject(values[i]);
-        dict.Add(key, value);
+        if (key != null) dict.Add(key, value);
       }
     }
   }


### PR DESCRIPTION
This adds a null check so that Add does not thow an ArgumentNullException if the DictionaryTransformer cannot deserialize a key-value pair's key. This only handles reference types and nullable value types. However, unknown value types are not considered yet, and Add will throw an ArgumentException once the transformer tries to add another key-value pair with a key that has already been added.

Closes #28.