### PR TITLE
Switch to AssemblyLoadContext for assembly retrival

### DIFF
--- a/src/HEAL.Attic.Benchmarks/HEAL.Attic.Benchmarks.csproj
+++ b/src/HEAL.Attic.Benchmarks/HEAL.Attic.Benchmarks.csproj
@@ -1,20 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-	<PropertyGroup>
-		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
-		<Version>1.8.0</Version>
-		<RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
-		<EnableNETAnalyzers>true</EnableNETAnalyzers>
-		<NeutralLanguage></NeutralLanguage>
-	</PropertyGroup>
-
-	<ItemGroup>
-		<PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<ProjectReference Include="..\HEAL.Attic\HEAL.Attic.csproj" />
-	</ItemGroup>
-
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Version>1.8.0</Version>
+    <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <NeutralLanguage>
+    </NeutralLanguage>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\HEAL.Attic\HEAL.Attic.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/HEAL.Attic.Tests/HEAL.Attic.Tests.csproj
+++ b/src/HEAL.Attic.Tests/HEAL.Attic.Tests.csproj
@@ -1,20 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Version>1.8.0</Version>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
-    <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.7" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\HEAL.Attic\HEAL.Attic.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/HEAL.Attic/Core/StaticCache.cs
+++ b/src/HEAL.Attic/Core/StaticCache.cs
@@ -10,6 +10,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
+using System.Runtime.Loader;
 
 namespace HEAL.Attic {
   public sealed class StaticCache {
@@ -137,7 +138,7 @@ namespace HEAL.Attic {
     }
 
     public void UpdateRegisteredTypes() {
-      foreach (var asm in AppDomain.CurrentDomain.GetAssemblies()) {
+      foreach (var asm in AssemblyLoadContext.Default.Assemblies) {
         if (asm.IsDynamic) continue;
         if (cachedAssemblies.Contains(asm.FullName)) continue;
         cachedAssemblies.Add(asm.FullName);

--- a/src/HEAL.Attic/HEAL.Attic.csproj
+++ b/src/HEAL.Attic/HEAL.Attic.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <Authors>Heuristic and Evolutionary Algorithms Laboratory (HEAL) and Contributors</Authors>
     <Company>University of Applied Sciences Upper Austria</Company>
     <Copyright>(c) Heuristic and Evolutionary Algorithms Laboratory (HEAL)</Copyright>
@@ -14,11 +13,9 @@
     <RepositoryType>git</RepositoryType>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.15.0" />
-    <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
     <None Include="../../LICENSE.txt" Pack="true" PackagePath="" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.7" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
With .NET (core) a new mechanism for assembly loading/plugin discovery has been introduced: `AssemblyLoadContext`. It allows to have multiple contexts and each can load and unload assemblies. The problem is that they are all (from all AssemblyLoadContexts) returned by `AppDomain.CurrentDomain.GetAssemblies()`. This is problematic as `AssemblyLoadContext.Unload()` does not immediately unload assemblies but marks them for removal by the `GC. GetAssemblies()` therefore returns assemblies that might get GC'ed at a later point in time. 
Additionally, having the same assembly loaded multiple times breaks Attic and leads to not finding any transformers at all and as a result prevents saving/loading of files. 

Therefore, `AppDomain.CurrentDomain.GetAssemblies()` is replaced with `AssemblyLoadContext.Default.Assemblies` in this PR to only return the assemblies from the default context. `AssemblyLoadContext.Default.Assemblies` only works with .NET, therefore the project was upgraded to .NET 8 and support for netstandard2.0 and net472 was dropped. 